### PR TITLE
feat(kube-apiserver): Add missing restart handle on upload

### DIFF
--- a/roles/k8s-api-server/tasks/main.yml
+++ b/roles/k8s-api-server/tasks/main.yml
@@ -15,6 +15,8 @@
   ansible.builtin.copy:
     src: "ca-key.pem"
     dest: /var/lib/kubernetes
+  notify:
+    - "Restart Kubernetes API server"
 
 - name: Upload certificate authority public key
   ansible.builtin.copy:


### PR DESCRIPTION
This PR aims to add a missing handler to restart the service on configuration file changes.