### PR TITLE
feat(kube-apiserver): Add status check after installation

### DIFF
--- a/roles/k8s-api-server/tasks/main.yml
+++ b/roles/k8s-api-server/tasks/main.yml
@@ -72,3 +72,9 @@
     name: kube-apiserver
     enabled: yes
     state: started
+
+- name: Ensure current kube-apiserver status
+  ansible.builtin.uri:
+    url: https://localhost:6443/livez
+    validate_certs: false
+


### PR DESCRIPTION
This PR aims to validate the `kube-apiserver` installation.